### PR TITLE
Refactor npm tasks in build.gradle to use NpmTask

### DIFF
--- a/source/did-verifier-server/build.gradle
+++ b/source/did-verifier-server/build.gradle
@@ -103,6 +103,8 @@ tasks.named('test') {
     useJUnitPlatform()
 }
 
+
+import com.github.gradle.node.npm.task.NpmTask
 import com.github.jk1.license.render.*
 import com.github.jk1.license.filter.LicenseBundleNormalizer
 import com.github.jk1.license.filter.ExcludeTransitiveDependenciesFilter
@@ -119,7 +121,7 @@ licenseReport {
 
 node {
     version = "22.9.0"
-    download = false
+    download = true
     nodeProjectDir = file("${frontendResourceDir}")
     workDir = file("${projectDir}/.gradle/nodejs")
     npmWorkDir = file("${projectDir}/.gradle/npm")
@@ -132,16 +134,17 @@ tasks.register('deleteFrontResources', Delete) {
     delete "${frontendResourceDir}/dist"
 }
 
-tasks.register('npm_install', Exec) {
+tasks.register('npm_install', NpmTask) {
+    dependsOn tasks.named("nodeSetup")
     workingDir = file("${frontendResourceDir}")
-    commandLine = ["npm", "install"]
+    args = ['install']
 }
 
-tasks.register('npm_build', Exec) {
+tasks.register('npm_build', NpmTask) {
     dependsOn 'deleteFrontResources'
     dependsOn 'npm_install'
     workingDir = file("${frontendResourceDir}")
-    commandLine = ["npm", "run", "build"]
+    args = ['run', 'build']
 }
 
 tasks.register('copyFrontResources', Copy) {
@@ -159,4 +162,5 @@ tasks.named('processResources') {
     if (!Boolean.valueOf(skipFrontendBuild)) {
         dependsOn('npm_build', 'copyFrontResources')
     }
+
 }


### PR DESCRIPTION
## Description
Refactored build.gradle to replace Exec-based npm tasks with NpmTask.  
This change improves integration with the Gradle Node plugin and ensures stable and consistent npm execution by depending on nodeSetup.

## Related Issue (Optional)
- Issue #

## Changes
- Updated npm_install and npm_build tasks to use NpmTask instead of Exec
- Added dependsOn nodeSetup for npm_install to ensure Node environment setup
- Improved build stability and consistency for npm-related tasks

## Screenshots (Optional)

## Additional Comments (Optional)
