### PR TITLE
Update verifier initial status in Liquibase seed data to DEACTIVATE

### DIFF
--- a/source/did-verifier-server/src/main/resources/db/changelog/data/verifier.csv
+++ b/source/did-verifier-server/src/main/resources/db/changelog/data/verifier.csv
@@ -1,2 +1,2 @@
 id,did,name,status
-1,did:omn:verifier,Verifier,ACTIVATE
+1,did:omn:verifier,Verifier,DEACTIVATE


### PR DESCRIPTION
## Description
Updated Liquibase CSV seed data to change the default verifier status from ACTIVATE to DEACTIVATE.  

## Related Issue (Optional)
- Issue #

## Changes
- Modified verifier CSV seed data in Liquibase changelog
- Changed default status value from ACTIVATE to DEACTIVATE

## Screenshots (Optional)

## Additional Comments (Optional)
