### PR TITLE
fix: FeignClient is not registered properly

### DIFF
--- a/source/did-verifier-server/src/main/java/org/omnione/did/VerifierApplication.java
+++ b/source/did-verifier-server/src/main/java/org/omnione/did/VerifierApplication.java
@@ -25,7 +25,6 @@ import org.springframework.cloud.openfeign.EnableFeignClients;
 @SpringBootApplication
 @ConfigurationPropertiesScan(basePackages = "org.omnione.did.base.property")
 @Slf4j
-@EnableFeignClients
 public class VerifierApplication {
 
     public static void main(String[] args)  {

--- a/source/did-verifier-server/src/main/java/org/omnione/did/base/config/OpenFeignConfig.java
+++ b/source/did-verifier-server/src/main/java/org/omnione/did/base/config/OpenFeignConfig.java
@@ -27,7 +27,7 @@ import org.springframework.context.annotation.Configuration;
  * This class also provides a RequestInterceptor bean that adds a Content-Type header to all requests.
  */
 @Configuration
-@EnableFeignClients("org.omnione.did.verifier.v1.api")
+@EnableFeignClients("org.omnione.did.verifier.v1")
 public class OpenFeignConfig {
     @Bean
     public RequestInterceptor requestInterceptor() {

--- a/source/did-verifier-server/src/test/java/org/omnione/did/base/config/OpenFeignConfigTest.java
+++ b/source/did-verifier-server/src/test/java/org/omnione/did/base/config/OpenFeignConfigTest.java
@@ -1,0 +1,29 @@
+package org.omnione.did.base.config;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.context.ApplicationContext;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * Verify OpenFeign Client is registered properly
+ *
+ * @author birariro
+ */
+@SpringBootTest(classes = {OpenFeignConfig.class})
+class OpenFeignConfigTest {
+
+    @Autowired
+    private ApplicationContext ctx;
+
+    @Test
+    void atLeastOneFeignClientBeanShouldExist() {
+        String[] feignBeans = ctx.getBeanNamesForAnnotation(FeignClient.class);
+
+        assertThat(feignBeans).isNotEmpty();
+    }
+}


### PR DESCRIPTION
'basePackages' of 'EnableFeignClient' is incorrectly registered and the 'FeignClient' bean is not registered properly