### PR TITLE
hotfix: update Dockerfile Java image to eclipse-temurin 21 (jammy)

### DIFF
--- a/source/Dockerfile
+++ b/source/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:21-jdk-slim
+FROM eclipse-temurin:21-jdk-jammy
 
 WORKDIR /app
 


### PR DESCRIPTION
Previous base image (openjdk:21-jdk-slim) is no longer supported.

## Description
<!-- Briefly describe the changes in this pull request. -->
This pull request updates the Java base image in the Dockerfile from openjdk:21-jdk-slim to eclipse-temurin:21-jdk-jammy.
Previous base image (openjdk:21-jdk-slim) is no longer supported.

## Related Issue (Optional)
<!-- Mention the issue number that this PR addresses. -->
- Issue # (e.g., #123)

## Changes
<!-- List your changes in detail and what reviewers should focus on -->
Updated the Dockerfile base image from openjdk:21-jdk-slim to eclipse-temurin:21-jdk-jammy.

## Screenshots (Optional)
<!-- Attach screenshots or GIFs to show the changes, if applicable. -->

## Additional Comments (Optional)
<!-- Any other comments or information that reviewers should be aware of. -->
No functional changes are expected. This change ensures continued support and updates for the Java runtime base image.